### PR TITLE
refactor(inventory/item): padronizar uso de enums nos DTOs

### DIFF
--- a/src/main/java/com/smartlist/api/inventory/item/dto/ItemRegisterRequestDTO.java
+++ b/src/main/java/com/smartlist/api/inventory/item/dto/ItemRegisterRequestDTO.java
@@ -1,6 +1,8 @@
 package com.smartlist.api.inventory.item.dto;
 
 import com.smartlist.api.inventory.category.model.Category;
+import com.smartlist.api.inventory.item.enums.AverageConsumptionUnit;
+import com.smartlist.api.inventory.item.enums.UnitOfMeasure;
 import com.smartlist.api.user.model.User;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -18,15 +20,15 @@ public record ItemRegisterRequestDTO(
     @DecimalMin(value = "0.001")
     BigDecimal quantity,
 
-    @NotBlank
-    String unit,
+    @NotNull
+    UnitOfMeasure unit,
 
     @NotNull
     @DecimalMin(value = "0.001")
     BigDecimal avgConsumptionValue,
 
-    @NotBlank
-    String avgConsumptionUnit,
+    @NotNull
+    AverageConsumptionUnit avgConsumptionUnit,
 
     @NotNull
     @DecimalMin(value = "0.00")

--- a/src/main/java/com/smartlist/api/inventory/item/dto/ItemUpdateRequestDTO.java
+++ b/src/main/java/com/smartlist/api/inventory/item/dto/ItemUpdateRequestDTO.java
@@ -1,5 +1,7 @@
 package com.smartlist.api.inventory.item.dto;
 
+import com.smartlist.api.inventory.item.enums.AverageConsumptionUnit;
+import com.smartlist.api.inventory.item.enums.UnitOfMeasure;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,8 +19,8 @@ public record ItemUpdateRequestDTO(
         @DecimalMin(value = "0.001")
         BigDecimal quantity,
 
-        @NotBlank
-        String unit,
+        @NotNull
+        UnitOfMeasure unit,
 
         @NotNull
         @DecimalMin(value = "0.00")
@@ -28,8 +30,8 @@ public record ItemUpdateRequestDTO(
         @DecimalMin(value = "0.001")
         BigDecimal avgConsumptionValue,
 
-        @NotBlank
-        String avgConsumptionUnit,
+        @NotNull
+        AverageConsumptionUnit avgConsumptionUnit,
 
         @NotNull
         Long categoryId

--- a/src/main/java/com/smartlist/api/inventory/item/enums/AverageConsumptionUnit.java
+++ b/src/main/java/com/smartlist/api/inventory/item/enums/AverageConsumptionUnit.java
@@ -1,5 +1,8 @@
 package com.smartlist.api.inventory.item.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.smartlist.api.exceptions.BadRequestException;
+
 public enum AverageConsumptionUnit {
     DAY("dia"),
     WEEK("semana"),
@@ -15,23 +18,14 @@ public enum AverageConsumptionUnit {
         return label;
     }
 
-    public static boolean isValid(String value) {
+    @JsonCreator
+    public static AverageConsumptionUnit fromString(String value) {
         for (AverageConsumptionUnit unit : AverageConsumptionUnit.values()) {
-            if (unit.getLabel().equalsIgnoreCase(value)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public static AverageConsumptionUnit fromLabel(String label) {
-        for (AverageConsumptionUnit unit : AverageConsumptionUnit.values()) {
-            if (unit.getLabel().equalsIgnoreCase(label)) {
+            if (unit.getLabel().equalsIgnoreCase(value) || unit.name().equalsIgnoreCase(value)) {
                 return unit;
             }
         }
 
-        throw new IllegalArgumentException("Unidade inválida: " + label);
+        throw new BadRequestException("EACU1001", "Unidade de medida inválida: " + value);
     }
 }

--- a/src/main/java/com/smartlist/api/inventory/item/enums/UnitOfMeasure.java
+++ b/src/main/java/com/smartlist/api/inventory/item/enums/UnitOfMeasure.java
@@ -1,5 +1,8 @@
 package com.smartlist.api.inventory.item.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.smartlist.api.exceptions.BadRequestException;
+
 public enum UnitOfMeasure {
     UNIT("unidade"),
     KG("quilograma"),
@@ -20,23 +23,14 @@ public enum UnitOfMeasure {
         return label;
     }
 
-    public static boolean isValid(String value) {
+    @JsonCreator
+    public static UnitOfMeasure fromString(String value) {
         for (UnitOfMeasure unit : UnitOfMeasure.values()) {
-            if (unit.getLabel().equalsIgnoreCase(value)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public static UnitOfMeasure fromLabel(String label) {
-        for (UnitOfMeasure unit : UnitOfMeasure.values()) {
-            if (unit.getLabel().equalsIgnoreCase(label)) {
+            if (unit.getLabel().equalsIgnoreCase(value) || unit.name().equalsIgnoreCase(value)) {
                 return unit;
             }
         }
 
-        throw new IllegalArgumentException("Unidade inválida: " + label);
+        throw new BadRequestException("EUOM1001", "Unidade de medida inválida: " + value);
     }
 }

--- a/src/main/java/com/smartlist/api/inventory/item/service/ItemService.java
+++ b/src/main/java/com/smartlist/api/inventory/item/service/ItemService.java
@@ -49,22 +49,14 @@ public class ItemService {
     public void register(ItemRegisterRequestDTO dto, User user) {
         log.info("Iniciando cadastro de item");
 
-        if (!UnitOfMeasure.isValid(dto.unit())) {
-            throw new BadRequestException("I1001", "Unidade de medida inválida");
-        }
-
-        if (!AverageConsumptionUnit.isValid(dto.avgConsumptionUnit())) {
-            throw new BadRequestException("I1002", "Período de média de consumo inválido");
-        }
-
         Item item = new Item();
         item.setUser(user);
         item.setName(dto.name());
         item.setQuantity(dto.quantity());
         item.setPrice(dto.price());
-        item.setUnit(UnitOfMeasure.fromLabel(dto.unit()));
+        item.setUnit(dto.unit());
         item.setAvgConsumptionValue(dto.avgConsumptionValue());
-        item.setAvgConsumptionUnit(AverageConsumptionUnit.fromLabel(dto.avgConsumptionUnit()));
+        item.setAvgConsumptionUnit(dto.avgConsumptionUnit());
 
         item.setAvgConsumptionPerDay(convertToDailyAverage(dto.avgConsumptionValue(), item.getAvgConsumptionUnit()));
 
@@ -100,12 +92,8 @@ public class ItemService {
             item.setQuantity(dto.quantity());
         }
 
-        if (!dto.unit().equals(item.getUnit().getLabel())) {
-            if (!UnitOfMeasure.isValid(dto.unit())) {
-                throw new BadRequestException("I1001", "Unidade de medida inválida");
-            }
-
-            item.setUnit(UnitOfMeasure.fromLabel(dto.unit()));
+        if (!dto.unit().equals(item.getUnit())) {
+            item.setUnit(dto.unit());
         }
 
         if (!dto.price().equals(item.getPrice())) {
@@ -123,12 +111,7 @@ public class ItemService {
             shouldRecalculateAvgPerDay = true;
         }
 
-        if (!dto.avgConsumptionUnit().equals(item.getAvgConsumptionUnit().name())) {
-            if (!AverageConsumptionUnit.isValid(dto.avgConsumptionUnit())) {
-                throw new BadRequestException("I1002", "Período de média de consumo inválido");
-            }
-
-            item.setAvgConsumptionUnit(AverageConsumptionUnit.fromLabel(dto.avgConsumptionUnit()));
+        if (!dto.avgConsumptionUnit().equals(item.getAvgConsumptionUnit())) {
             shouldRecalculateAvgPerDay = true;
         }
 


### PR DESCRIPTION
## Refactor: Padronizar o uso de enums nos DTOs

- Padronização dos Enums `UnitOfMeasure` e `AverageConsumptionUnit` para serem usados diretamente nos DTOs.