### PR TITLE
refactor: padronizar endpoints da API seguindo REST

### DIFF
--- a/src/main/java/com/smartlist/api/inventory/category/controller/CategoryController.java
+++ b/src/main/java/com/smartlist/api/inventory/category/controller/CategoryController.java
@@ -55,7 +55,7 @@ public class CategoryController {
         return ResponseEntity.ok("Categoria registrada com sucesso.");
     }
 
-    @PostMapping("/update")
+    @PatchMapping("/update")
     public ResponseEntity<String> update(@RequestBody @Valid CategoryUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         categoryService.update(updateRequestDTO, user);

--- a/src/main/java/com/smartlist/api/inventory/item/controller/ItemController.java
+++ b/src/main/java/com/smartlist/api/inventory/item/controller/ItemController.java
@@ -48,7 +48,7 @@ public class ItemController {
         return ResponseEntity.ok("Item cadastrado com sucesso.");
     }
 
-    @PostMapping("/item/update")
+    @PatchMapping("/item/update")
     public ResponseEntity<String> update(@RequestBody @Valid ItemUpdateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         itemService.update(requestDTO, user);

--- a/src/main/java/com/smartlist/api/shoppinglist/controller/ShoppingListController.java
+++ b/src/main/java/com/smartlist/api/shoppinglist/controller/ShoppingListController.java
@@ -32,7 +32,7 @@ public class ShoppingListController {
         return ResponseEntity.ok(shoppingListDTO);
     }
 
-    @PostMapping("/update-item")
+    @PatchMapping("/update-item")
     public ResponseEntity<String> updateShoppingListItem(@Valid @RequestBody ShoppingListItemUpdateRequest dto) {
         shoppingListService.updateShoppingListItem(dto);
         return ResponseEntity.ok("Item atualizado com sucesso");


### PR DESCRIPTION
## Refactor: Padronização dos endpoints da API seguindo REST

Refatora os endpoints de atualização da API para seguir a semântica REST, substituindo POST por PATCH quando apropriado.

### Endpoints afetados:
- `POST /inventory/category/update` -> `PATCH /inventory/category/update`
- `POST /inventory/item/update` -> `PATCH /inventory/item/update`
- `POST /shopping-list/update-item` -> `PATCH /shopping-list/update-item`