### PR TITLE
refactor(shared): adicionar ApiResponse<T> e padronizar respostas da API

### DIFF
--- a/src/main/java/com/smartlist/api/auth/controller/AuthController.java
+++ b/src/main/java/com/smartlist/api/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.smartlist.api.auth.controller;
 
 import com.smartlist.api.auth.dto.LoginDTO;
+import com.smartlist.api.auth.dto.TokenResponseDTO;
 import com.smartlist.api.auth.service.AuthService;
 import com.smartlist.api.exceptions.InvalidCredentialsException;
+import com.smartlist.api.shared.dto.ApiResponse;
 import com.smartlist.api.user.repository.UserRepository;
 import com.smartlist.api.user.model.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +28,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public String login(@RequestBody @Valid LoginDTO loginDTO, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<TokenResponseDTO>> login(@RequestBody @Valid LoginDTO loginDTO, HttpServletResponse response) {
         authService.authenticate(loginDTO);
 
         String accessToken = authService.createAccessToken(loginDTO.email());
@@ -41,18 +43,18 @@ public class AuthController {
 
         response.setHeader("Set-Cookie", cookieHeader);
 
-        return accessToken;
+        return ResponseEntity.ok(new ApiResponse<>(true, "Login efetuado com sucesso.", new TokenResponseDTO(accessToken)));
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<TokenResponseDTO>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
         String newAccessToken = authService.refreshToken(request, response);
-        return ResponseEntity.ok(newAccessToken);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Token atualizado com sucesso.", new TokenResponseDTO(newAccessToken)));
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
         authService.logout(request, response);
-        return ResponseEntity.ok("Logout efetuado com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Logout efetuado com sucesso.", null));
     }
 }

--- a/src/main/java/com/smartlist/api/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/com/smartlist/api/auth/dto/TokenResponseDTO.java
@@ -1,0 +1,6 @@
+package com.smartlist.api.auth.dto;
+
+public record TokenResponseDTO(
+        String accessToken
+) {
+}

--- a/src/main/java/com/smartlist/api/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/smartlist/api/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.smartlist.api.exceptions;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.smartlist.api.shared.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,39 +17,43 @@ import java.util.Map;
 @ControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(EmailAlreadyExistsException.class)
-    public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(EmailAlreadyExistsException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleEmailAlreadyExists(EmailAlreadyExistsException ex) {
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(PhoneNumberRequiredException.class)
-    public ResponseEntity<ErrorResponse> handlePhoneNumberRequired(PhoneNumberRequiredException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handlePhoneNumberRequired(PhoneNumberRequiredException ex) {
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(WeakPasswordException.class)
-    public ResponseEntity<ErrorResponse> handleWeakPassword(WeakPasswordException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleWeakPassword(WeakPasswordException ex) {
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return  ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
 
         log.warn("Falha na validação de campos da requisição: {}", errors);
 
-        return ResponseEntity.badRequest().body(errors);
+        return ResponseEntity.badRequest().body(new ApiResponse<>(false, "Erro de validação", errors));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> handleHttpNotReadable(HttpMessageNotReadableException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleHttpNotReadable(HttpMessageNotReadableException ex) {
         Throwable cause = ex.getCause();
+        Map<String, String> errorData = new HashMap<>();
 
         if (cause instanceof InvalidFormatException invalidFormatEx) {
             if (invalidFormatEx.getPath() != null && !invalidFormatEx.getPath().isEmpty()) {
@@ -56,54 +61,64 @@ public class GlobalExceptionHandler {
 
                 if ("notificationPreference".equals(fieldName)) {
                     log.warn("Valor inválido para notificationPreference");
+                    errorData.put("code", "004");
+
                     return ResponseEntity.badRequest().body(
-                        new ErrorResponse("004", "notificationPreference deve ser um dos seguintes valores: EMAIL, WHATSAPP, BOTH")
+                            new ApiResponse<>(false,
+                                    "notificationPreference deve ser um dos seguintes valores: EMAIL, WHATSAPP, BOTH",
+                                    errorData)
                     );
                 }
             }
         }
 
         log.warn("Requisição mal formatada: {}", ex.getMessage());
+        errorData.put("code", "005");
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse("005", "Requisição mal formatada ou dados inválidos"));
+                .body(new ApiResponse<>(false, "Requisição mal formatada ou dados inválidos", errorData));
     }
 
     @ExceptionHandler(InvalidJwtException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidJwt(InvalidJwtException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleInvalidJwt(InvalidJwtException ex) {
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(InvalidCredentialsException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleInvalidCredentials(InvalidCredentialsException ex) {
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(EmailSendException.class)
-    public ResponseEntity<ErrorResponse> handleEmailSendException(EmailSendException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleEmailSendException(EmailSendException ex) {
         log.error("Erro ao enviar email: {}", ex.getMessage(), ex);
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleBadRequestException(BadRequestException ex) {
+        Map<String, String> errorData = Map.of("code", ex.getCode());
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+                .body(new ApiResponse<>(false, ex.getMessage(), errorData));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleUnexpected(Exception ex) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleUnexpected(Exception ex) {
         log.error("Erro inesperado não tratado: {}", ex.getMessage(), ex);
+        Map<String, String> errorData = Map.of("code", "500");
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse("500", "Erro interno no servidor. Tente novamente mais tarde."));
+                .body(new ApiResponse<>(false, "Erro interno no servidor. Tente novamente mais tarde.", errorData));
     }
 }

--- a/src/main/java/com/smartlist/api/inventory/category/controller/CategoryController.java
+++ b/src/main/java/com/smartlist/api/inventory/category/controller/CategoryController.java
@@ -5,6 +5,7 @@ import com.smartlist.api.inventory.category.dto.CategoryRegisterRequestDTO;
 import com.smartlist.api.inventory.category.dto.CategoryUpdateRequestDTO;
 import com.smartlist.api.inventory.category.dto.CategoryListResponseDTO;
 import com.smartlist.api.inventory.category.service.CategoryService;
+import com.smartlist.api.shared.dto.ApiResponse;
 import com.smartlist.api.user.model.User;
 import com.smartlist.api.userdetails.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -26,7 +27,7 @@ public class CategoryController {
     }
 
     @GetMapping
-    public ResponseEntity<PageResponse<CategoryListResponseDTO>> list(@AuthenticationPrincipal UserDetailsImpl userDetails, @PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<ApiResponse<PageResponse<CategoryListResponseDTO>>> list(@AuthenticationPrincipal UserDetailsImpl userDetails, @PageableDefault(size = 10) Pageable pageable) {
         User user = userDetails.getUser();
         Page<CategoryListResponseDTO> categories = categoryService.list(user, pageable);
 
@@ -38,34 +39,34 @@ public class CategoryController {
         response.setTotalPages(categories.getTotalPages());
         response.setLast(categories.isLast());
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Categorias páginadas listadas com sucesso.", response));
     }
 
     @GetMapping("/all")
-    public ResponseEntity<List<CategoryListResponseDTO>> listAll(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<List<CategoryListResponseDTO>>> listAll(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         List<CategoryListResponseDTO> categories = categoryService.listAll(user);
-        return ResponseEntity.ok(categories);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Categorias listadas com sucesso.", categories));
     }
 
     @PostMapping("/register")
-    public ResponseEntity<String> register(@RequestBody @Valid CategoryRegisterRequestDTO registerRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid CategoryRegisterRequestDTO registerRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         categoryService.register(registerRequestDTO, user);
-        return ResponseEntity.ok("Categoria registrada com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Categoria registrada com sucesso.", null));
     }
 
     @PostMapping("/update")
-    public ResponseEntity<String> update(@RequestBody @Valid CategoryUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> update(@RequestBody @Valid CategoryUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         categoryService.update(updateRequestDTO, user);
-        return ResponseEntity.ok("Categoria atualizada com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Categoria atualizada com sucesso.", null));
     }
 
     @DeleteMapping("/delete/{id}")
-    public ResponseEntity<String> delete(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         categoryService.deleteById(id, user);
-        return ResponseEntity.ok("Categoria excluída com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Categoria excluída com sucesso.", null));
     }
 }

--- a/src/main/java/com/smartlist/api/inventory/item/controller/ItemController.java
+++ b/src/main/java/com/smartlist/api/inventory/item/controller/ItemController.java
@@ -5,6 +5,7 @@ import com.smartlist.api.inventory.item.dto.ItemListResponseDTO;
 import com.smartlist.api.inventory.item.dto.ItemRegisterRequestDTO;
 import com.smartlist.api.inventory.item.dto.ItemUpdateRequestDTO;
 import com.smartlist.api.inventory.item.service.ItemService;
+import com.smartlist.api.shared.dto.ApiResponse;
 import com.smartlist.api.user.model.User;
 import com.smartlist.api.userdetails.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -26,7 +27,7 @@ public class ItemController {
     }
 
     @GetMapping
-    public ResponseEntity<PageResponse<ItemListResponseDTO>> list(@AuthenticationPrincipal UserDetailsImpl userDetails, @PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<ApiResponse<PageResponse<ItemListResponseDTO>>> list(@AuthenticationPrincipal UserDetailsImpl userDetails, @PageableDefault(size = 10) Pageable pageable) {
         User user = userDetails.getUser();
         Page<ItemListResponseDTO> items = itemService.list(user, pageable);
 
@@ -38,27 +39,27 @@ public class ItemController {
         response.setTotalPages(items.getTotalPages());
         response.setLast(items.isLast());
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Itens listados com sucesso.", response));
     }
 
     @PostMapping("/item/register")
-    public ResponseEntity<String> register(@RequestBody @Valid ItemRegisterRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid ItemRegisterRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         itemService.register(requestDTO, user);
-        return ResponseEntity.ok("Item cadastrado com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Item cadastrado com sucesso.", null));
     }
 
     @PostMapping("/item/update")
-    public ResponseEntity<String> update(@RequestBody @Valid ItemUpdateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> update(@RequestBody @Valid ItemUpdateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         itemService.update(requestDTO, user);
-        return ResponseEntity.ok("Item atualizado com sucesso");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Item atualizado com sucesso", null));
     }
 
     @DeleteMapping("/item/delete/{itemId}")
-    public ResponseEntity<String> delete(@PathVariable Long itemId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long itemId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         itemService.deleteById(itemId, user);
-        return ResponseEntity.ok("Item excluído com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Item excluído com sucesso.", null));
     }
 }

--- a/src/main/java/com/smartlist/api/inventory/item/controller/UnitOfMeasureController.java
+++ b/src/main/java/com/smartlist/api/inventory/item/controller/UnitOfMeasureController.java
@@ -2,6 +2,7 @@ package com.smartlist.api.inventory.item.controller;
 
 import com.smartlist.api.inventory.item.dto.UnitOfMeasureResponseDTO;
 import com.smartlist.api.inventory.item.enums.UnitOfMeasure;
+import com.smartlist.api.shared.dto.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,11 +16,11 @@ import java.util.stream.Collectors;
 public class UnitOfMeasureController {
 
     @GetMapping
-    public ResponseEntity<List<UnitOfMeasureResponseDTO>> getAllUnits() {
+    public ResponseEntity<ApiResponse<List<UnitOfMeasureResponseDTO>>> getAllUnits() {
         List<UnitOfMeasureResponseDTO> units = Arrays.stream(UnitOfMeasure.values())
                 .map(unit -> new UnitOfMeasureResponseDTO(unit.name(), unit.getLabel()))
                 .collect(Collectors.toList());
 
-        return ResponseEntity.ok(units);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Unidades de medida listadas com sucesso.", units));
     }
 }

--- a/src/main/java/com/smartlist/api/passwordreset/controller/PasswordResetController.java
+++ b/src/main/java/com/smartlist/api/passwordreset/controller/PasswordResetController.java
@@ -3,6 +3,7 @@ package com.smartlist.api.passwordreset.controller;
 import com.smartlist.api.passwordreset.dto.PasswordExchangeDTO;
 import com.smartlist.api.passwordreset.dto.PasswordResetRequestDTO;
 import com.smartlist.api.passwordreset.service.PasswordResetService;
+import com.smartlist.api.shared.dto.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -20,20 +21,20 @@ public class PasswordResetController {
     }
 
     @PostMapping("/request")
-    public ResponseEntity<String> requestPasswordReset(@RequestBody @Valid PasswordResetRequestDTO request) {
+    public ResponseEntity<ApiResponse<Void>> requestPasswordReset(@RequestBody @Valid PasswordResetRequestDTO request) {
         passwordResetService.requestPasswordReset(request);
-        return ResponseEntity.ok("Se o email existir em nosso sistema, instruções serão enviadas.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Se o email existir em nosso sistema, instruções serão enviadas.", null));
     }
 
     @GetMapping("/validate")
-    public ResponseEntity<String> validatePasswordResetToken(@RequestParam UUID token) {
+    public ResponseEntity<ApiResponse<Void>> validatePasswordResetToken(@RequestParam UUID token) {
         passwordResetService.validateToken(token);
-        return ResponseEntity.ok("Token válido.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Token válido.", null));
     }
 
     @PostMapping("/reset")
-    public ResponseEntity<String> resetPassword(@RequestBody @Valid PasswordExchangeDTO passwordExchangeDTO) {
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Valid PasswordExchangeDTO passwordExchangeDTO) {
         passwordResetService.resetPassword(passwordExchangeDTO);
-        return ResponseEntity.ok("Redefinição de senha realizada com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Redefinição de senha realizada com sucesso.", null));
     }
 }

--- a/src/main/java/com/smartlist/api/shared/dto/ApiResponse.java
+++ b/src/main/java/com/smartlist/api/shared/dto/ApiResponse.java
@@ -1,0 +1,7 @@
+package com.smartlist.api.shared.dto;
+
+public record ApiResponse<T> (
+        boolean sucess,
+        String message,
+        T data
+) {}

--- a/src/main/java/com/smartlist/api/shoppinglist/controller/ShoppingListController.java
+++ b/src/main/java/com/smartlist/api/shoppinglist/controller/ShoppingListController.java
@@ -1,5 +1,6 @@
 package com.smartlist.api.shoppinglist.controller;
 
+import com.smartlist.api.shared.dto.ApiResponse;
 import com.smartlist.api.shoppinglist.dto.ShoppingListDTO;
 import com.smartlist.api.shoppinglist.dto.ShoppingListItemUpdateRequest;
 import com.smartlist.api.shoppinglist.service.ShoppingListService;
@@ -20,27 +21,27 @@ public class ShoppingListController {
     }
 
     @GetMapping("/active")
-    public ResponseEntity<ShoppingListDTO> getActiveShoppingList(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<ShoppingListDTO>> getActiveShoppingList(@AuthenticationPrincipal UserDetailsImpl userDetails) {
             User user = userDetails.getUser();
         ShoppingListDTO shoppingListDTO = shoppingListService.getActiveShoppingListByUser(user);
-        return ResponseEntity.ok(shoppingListDTO);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista ativa obtida com sucesso.", shoppingListDTO));
     }
 
     @GetMapping("/{shoppingListId}")
-    public ResponseEntity<ShoppingListDTO> getShoppingListWithItems(@PathVariable Long shoppingListId) {
+    public ResponseEntity<ApiResponse<ShoppingListDTO>> getShoppingListWithItems(@PathVariable Long shoppingListId) {
         ShoppingListDTO shoppingListDTO = shoppingListService.getShoppingListWithItems(shoppingListId);
-        return ResponseEntity.ok(shoppingListDTO);
+        return ResponseEntity.ok(new ApiResponse<>(true, "Lista obtida com sucesso.", shoppingListDTO));
     }
 
     @PostMapping("/update-item")
-    public ResponseEntity<String> updateShoppingListItem(@Valid @RequestBody ShoppingListItemUpdateRequest dto) {
+    public ResponseEntity<ApiResponse<Void>> updateShoppingListItem(@Valid @RequestBody ShoppingListItemUpdateRequest dto) {
         shoppingListService.updateShoppingListItem(dto);
-        return ResponseEntity.ok("Item atualizado com sucesso");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Item atualizado com sucesso", null));
     }
 
     @DeleteMapping("/delete-item/{shoppingListItemId}")
-    public ResponseEntity<String> deleteShoppingListItem(@PathVariable Long shoppingListItemId) {
+    public ResponseEntity<ApiResponse<Void>> deleteShoppingListItem(@PathVariable Long shoppingListItemId) {
         shoppingListService.deleteShoppingListItemById(shoppingListItemId);
-        return ResponseEntity.ok("Item excluído com sucesso");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Item excluído com sucesso", null));
     }
 }

--- a/src/main/java/com/smartlist/api/user/controller/UserController.java
+++ b/src/main/java/com/smartlist/api/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.smartlist.api.user.controller;
 
+import com.smartlist.api.shared.dto.ApiResponse;
 import com.smartlist.api.user.dto.RegisterDTO;
 import com.smartlist.api.user.service.UserService;
 import jakarta.validation.Valid;
@@ -19,8 +20,8 @@ public class UserController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<String> register(@RequestBody @Valid RegisterDTO request) {
+    public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid RegisterDTO request) {
         userService.register(request);
-        return ResponseEntity.ok("Usuário registrado com sucesso.");
+        return ResponseEntity.ok(new ApiResponse<>(true, "Usuário registrado com sucesso.", null));
     }
 }


### PR DESCRIPTION
## Padronizar respostas da API com ApiResponse<T>

### Principais mudanças:
- Criação da classe ApiResponse<T> em shared.dto.
- Atualização dos controllers de recursos (Item, Category, ShoppingList, PasswordReset, Auth) para retornar ResponseEntity<ApiResponse<T>>.
- Atualização do GlobalExceptionHandler para usar ApiResponse<T> em todas as exceções tratadas.
- Endpoint de login/refresh/logout também padronizado com TokenResponseDTO dentro de ApiResponse<T>.
