### PR TITLE
refactor(shared): padronizar retorno de update para ApiResponse

### DIFF
--- a/src/main/java/com/smartlist/api/inventory/category/controller/CategoryController.java
+++ b/src/main/java/com/smartlist/api/inventory/category/controller/CategoryController.java
@@ -58,7 +58,7 @@ public class CategoryController {
 
 
     @PatchMapping("/update")
-    public ResponseEntity<String> update(@RequestBody @Valid CategoryUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> update(@RequestBody @Valid CategoryUpdateRequestDTO updateRequestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         categoryService.update(updateRequestDTO, user);
         return ResponseEntity.ok(new ApiResponse<>(true, "Categoria atualizada com sucesso.", null));

--- a/src/main/java/com/smartlist/api/inventory/item/controller/ItemController.java
+++ b/src/main/java/com/smartlist/api/inventory/item/controller/ItemController.java
@@ -50,7 +50,7 @@ public class ItemController {
     }
 
     @PatchMapping("/item/update")
-    public ResponseEntity<String> update(@RequestBody @Valid ItemUpdateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiResponse<Void>> update(@RequestBody @Valid ItemUpdateRequestDTO requestDTO, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         User user = userDetails.getUser();
         itemService.update(requestDTO, user);
         return ResponseEntity.ok(new ApiResponse<>(true, "Item atualizado com sucesso", null));

--- a/src/main/java/com/smartlist/api/shoppinglist/controller/ShoppingListController.java
+++ b/src/main/java/com/smartlist/api/shoppinglist/controller/ShoppingListController.java
@@ -34,7 +34,7 @@ public class ShoppingListController {
     }
 
     @PatchMapping("/update-item")
-    public ResponseEntity<String> updateShoppingListItem(@Valid @RequestBody ShoppingListItemUpdateRequest dto) {
+    public ResponseEntity<ApiResponse<Void>> updateShoppingListItem(@Valid @RequestBody ShoppingListItemUpdateRequest dto) {
         shoppingListService.updateShoppingListItem(dto);
         return ResponseEntity.ok(new ApiResponse<>(true, "Item atualizado com sucesso", null));
     }


### PR DESCRIPTION
## Refactor: padronizar retorno de update nos controllers

Padroniza os endpoints de atualização da API para retornarem ResponseEntity<ApiResponse<Void>> corrigindo métodos que antes retornavam ResponseEntity<String>.

### Principais mudanças:

 - CategoryController: endpoint PATCH /inventory/category/update agora retorna ApiResponse<Void>
 - ItemController: endpoint PATCH /inventory/item/update agora retorna ApiResponse<Void>
 - ShoppingListController: endpoint PATCH /shopping-list/update-item agora retorna ApiResponse<Void>