### PR TITLE
Fix/spring security authentication

### DIFF
--- a/src/main/java/com/smartlist/api/infra/config/SecurityConfig.java
+++ b/src/main/java/com/smartlist/api/infra/config/SecurityConfig.java
@@ -8,10 +8,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -44,6 +49,13 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+        AuthenticationConfiguration configuration
+    ) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean

--- a/src/main/java/com/smartlist/api/infra/config/SecurityConfig.java
+++ b/src/main/java/com/smartlist/api/infra/config/SecurityConfig.java
@@ -59,6 +59,17 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationProvider authenticationProvider(
+        UserDetailsService userDetailsService,
+        PasswordEncoder passwordEncoder
+    ) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
+    }
+
+    @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(corsProperties.getAllowedOrigins());
@@ -77,11 +88,12 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter, AuthenticationProvider authenticationProvider) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+		.authenticationProvider(authenticationProvider)
                 .headers(headers -> headers
                         .contentTypeOptions(Customizer.withDefaults())
                         .frameOptions(frame -> frame.sameOrigin())

--- a/src/main/java/com/smartlist/api/userdetails/CustomUserDetailsService.java
+++ b/src/main/java/com/smartlist/api/userdetails/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.smartlist.api.userdetails;
+
+import com.smartlist.api.user.model.User;
+import com.smartlist.api.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return new UserDetailsImpl(user);
+    }
+}
+


### PR DESCRIPTION
## O que foi feito

- Adicionado UserDetailsService para autenticação via email
- Registrado AuthenticationManager no contexto do Spring Security
- Implementado DaoAuthenticationProvider com UserDetailsService e PasswordEncoder
- Ajustado SecurityFilterChain para utilizar AuthenticationProvider corretamente

## Problema resolvido

O Spring Security estava utilizando autenticação padrão com usuário em memória,
gerando senha automática no startup da aplicação.

## Impacto

- Ativa autenticação correta via banco de dados
- Remove comportamento padrão inseguro do Spring Security
- Habilita fluxo correto de login JWT

## Observações

Essa mudança é crítica para o fluxo de autenticação da API.